### PR TITLE
Work around bug in Firebird

### DIFF
--- a/BenMAP/BatchCommonClass.cs
+++ b/BenMAP/BatchCommonClass.cs
@@ -269,7 +269,10 @@ namespace BenMAP
 					Console.WriteLine("Completed (Loaded " + lstBatchBase.Count + " Command)");
 
 				if (checkLog)
+				{
 					Console.WriteLine("Error Executing Batch File Command(s)" + Environment.NewLine + "Log Available at " + strFile + ".log");
+					return false;
+				}
 
 				ESIL.DBUtility.FireBirdHelperBase fb = new ESIL.DBUtility.ESILFireBirdHelper();
 

--- a/BenMAP/CommonClass.cs
+++ b/BenMAP/CommonClass.cs
@@ -264,6 +264,11 @@ namespace BenMAP
 					//need to modify string to use general data location
 					str = str.Replace("##USERDATA##", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
 
+					// Work around bug in Firebird that can randomly leave a connection open when
+					// shutting down. That causes an access violation or hangs the appliction on
+					// exit from batch mode. See http://tracker.firebirdsql.org/browse/DNET-806
+					str = str.Replace("pooling=True","pooling=False");
+
 					_connection = new FirebirdSql.Data.FirebirdClient.FbConnection(str);
 				}
 
@@ -311,8 +316,6 @@ namespace BenMAP
 			return connection;
 
 		}
-
-
 
 		public static List<BenMAPPollutant> LstPollutant; public static BenMAPGrid rBenMAPGrid;
 		public static void SaveCSV(DataTable dt, string fileName)

--- a/BenMAP/Main.cs
+++ b/BenMAP/Main.cs
@@ -327,15 +327,14 @@ namespace BenMAP
 		private void Main_Load(object sender, EventArgs e)
 		{
 			_projFileName = "";
+
 			if (CommonClass.BatchMode)
 			{
 				if (BatchCommonClass.RunBatch(CommonClass.InputParams[0]) == false)
-				{
-					Console.WriteLine("");
-					Console.WriteLine("Batch run unsuccessful");
-				};
-				Application.ExitThread();
+					Environment.Exit(1);
+				Environment.Exit(0);
 			}
+
 			CommonClass.BenMAPForm = _currentForm as BenMAP;
 			String errorcode = "0";
 			if (_currentForm == null)
@@ -812,7 +811,7 @@ namespace BenMAP
 			{
 				if (CommonClass.BatchMode)
 				{
-					e.Cancel = true;
+					e.Cancel = false;
 					return;
 				}
 				ExitConfirm exit = new ExitConfirm();
@@ -825,7 +824,11 @@ namespace BenMAP
 				DialogResult rtn = new DialogResult();
 				if (isShowExit == "T")
 				{ rtn = exit.ShowDialog(); }
-				if (rtn == System.Windows.Forms.DialogResult.Cancel) { e.Cancel = true; return; }
+				if (rtn == System.Windows.Forms.DialogResult.Cancel)
+				{
+					e.Cancel = true;
+					return;
+				}
 				deleteValidationLogFiles();
 			}
 			catch (Exception ex)

--- a/BenMAP/Program.cs
+++ b/BenMAP/Program.cs
@@ -7,7 +7,6 @@ using System.Configuration;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 
-
 namespace BenMAP
 {
 	static class Program
@@ -19,7 +18,7 @@ namespace BenMAP
 		private static extern bool AttachConsole(int pid);
 
 		[STAThread]
-		static int Main(string[] arg)
+		static void Main(string[] arg)
 		{
 			string strArg = "";
 			foreach (string s in arg)
@@ -82,11 +81,6 @@ namespace BenMAP
 			}
 
 			Application.Run(new Main());
-
-			if(CommonClass.BatchMode)
-				Console.WriteLine("Batch run complete");
-
-			return 0;
 		}
 
 		//static void FirstChanceExceptionHandler(object source, FirstChanceExceptionEventArgs args)


### PR DESCRIPTION
Turn connection pooling off to avoid a hang or access violation if
the fbintl DLL is unloaded before the pooled connections are all
shut down.

As a result of the workaround, the exit code can be simplified.