### PR TITLE
Remove console cursor positioning

### DIFF
--- a/BenMAP/APV/APVCommonClass.cs
+++ b/BenMAP/APV/APVCommonClass.cs
@@ -355,7 +355,7 @@ namespace BenMAP.APVX
 				if (valuationMethodPoolingAndAggregation.lstValuationMethodPoolingAndAggregationBase.First().lstAllSelectCRFunctionIncidenceAggregation == null)
 				{
 					bool isBatch = false;
-					if (CommonClass.InputParams != null && CommonClass.InputParams.Count() > 0 && CommonClass.InputParams[0].ToLower().Contains(".ctlx"))
+					if (CommonClass.BatchMode)
 					{
 						isBatch = true;
 					}

--- a/BenMAP/APV/SelectValuationMethods.cs
+++ b/BenMAP/APV/SelectValuationMethods.cs
@@ -788,19 +788,12 @@ To assign a valuation function to a given set of incidence results, click and dr
 			{
 				DialogResult rtn;
 				bool isBatch = false;
-				if (CommonClass.InputParams != null && CommonClass.InputParams.Count() > 0 && CommonClass.InputParams[0].ToLower().Contains(".ctlx"))
+				if (CommonClass.BatchMode)
 				{
 					isBatch = true;
 					CommonClass.BenMAPPopulation = CommonClass.ValuationMethodPoolingAndAggregation.BaseControlCRSelectFunctionCalculateValue.BenMAPPopulation;
 					CommonClass.GBenMAPGrid = CommonClass.ValuationMethodPoolingAndAggregation.BaseControlCRSelectFunctionCalculateValue.BaseControlGroup.First().GridType;
-				}
-				string apvProcess = "Processing APV File...";
-				if (isBatch)
-				{
-					Console.SetCursorPosition(0, Console.CursorTop);
-					Console.Write(new String(' ', Console.BufferWidth));
-					Console.SetCursorPosition(0, Console.CursorTop - 1);
-					Console.Write(apvProcess);
+					Console.Write("Processing APV File...");
 				}
 				if (CommonClass.ValuationMethodPoolingAndAggregation == null) { CommonClass.ValuationMethodPoolingAndAggregation = new ValuationMethodPoolingAndAggregation(); }
 
@@ -1326,14 +1319,10 @@ CommonClass.ValuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationA
 				TimeSpan ts = dtNow - dtRunStart;
 				CommonClass.ValuationMethodPoolingAndAggregation.lstLog = new List<string>();
 				CommonClass.ValuationMethodPoolingAndAggregation.lstLog.Add("Processing complete. Valuation processing time: " + ts.Hours + " hours " + ts.Minutes + " minutes " + ts.Seconds + " seconds.");
-				if (!isBatch) WaitClose();
+				if (!isBatch) 
+               WaitClose();
 				else
-				{
-					Console.SetCursorPosition(apvProcess.Length, Console.CursorTop);
-					Console.Write(new String(' ', Console.BufferWidth));
-					Console.SetCursorPosition(apvProcess.Length, Console.CursorTop - 1);
-					Console.Write("Completed" + Environment.NewLine);
-				}
+					Console.WriteLine("Completed");
 
 				CommonClass.ValuationMethodPoolingAndAggregation.CreateTime = DateTime.Now;
 				if (_filePath != "")
@@ -1344,25 +1333,17 @@ CommonClass.ValuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationA
 
 					if (APVX.APVCommonClass.SaveAPVRFile(_filePath, CommonClass.ValuationMethodPoolingAndAggregation))
 					{
-						if (!isBatch) MessageBox.Show("File saved.", "File saved");
+						if (!isBatch) 
+                     MessageBox.Show("File saved.", "File saved");
 						else
-						{
-							Console.SetCursorPosition(0, Console.CursorTop);
-							Console.Write(new String(' ', Console.BufferWidth));
-							Console.SetCursorPosition(0, Console.CursorTop - 1);
-							Console.WriteLine("Results Saved At:" + Environment.NewLine + _filePath);
-						}
+							Console.WriteLine("Results saved at: " + _filePath);
 					}
 					else
 					{
-						if (!isBatch) MessageBox.Show("Out of memory.", "Error");
+						if (!isBatch) 
+                     MessageBox.Show("Out of memory.", "Error");
 						else
-						{
-							Console.SetCursorPosition(0, Console.CursorTop);
-							Console.Write(new String(' ', Console.BufferWidth));
-							Console.SetCursorPosition(0, Console.CursorTop - 1);
 							Console.WriteLine("Error Saving APVR File");
-						}
 					}
 
 				}

--- a/BenMAP/BatchCommonClass.cs
+++ b/BenMAP/BatchCommonClass.cs
@@ -280,9 +280,6 @@ namespace BenMAP
 				foreach (BatchBase batchBase in lstBatchBase)
 				{
 					batchCount += 1;
-					//Console.SetCursorPosition(0, Console.CursorTop);
-					//Console.Write(new String(' ', Console.BufferWidth));
-					//Console.SetCursorPosition(0, Console.CursorTop - 1);
 					Console.WriteLine("---Running Command #" + batchCount + "---");
 					//CommonClass.ClearAllObject(); //Clear all object so that each batch action runs independently.
 					if (batchBase is BatchAQGBase)
@@ -757,19 +754,12 @@ namespace BenMAP
 						{
 							try
 							{
-								int prevTop = Console.CursorTop;
-								BenMAP benMAP = new BenMAP("");
-								int currTop = Console.CursorTop;
-								for (int i = currTop; i > prevTop - 1; i--)         //This code clears the command line of output text from appManager1.LoadExtensions(); in initialization of BenMAP
-								{
-									Console.SetCursorPosition(0, i);
-									Console.Write(new String(' ', Console.BufferWidth));
-								}
-								Console.SetCursorPosition(0, prevTop);
 
-								BatchReportCFGR batchReportCFGR = batchBase as BatchReportCFGR;
+								BenMAP benMAP = new BenMAP("");
 
 								Console.Write("Generating Report (CFGR)...");
+								BatchReportCFGR batchReportCFGR = batchBase as BatchReportCFGR;
+
 								benMAP._outputFileName = batchReportCFGR.ReportFile;
 								string err = "";
 								BaseControlCRSelectFunctionCalculateValue bControlCR = Configuration.ConfigurationCommonClass.LoadCFGRFile(batchReportCFGR.InputFile, ref err);
@@ -1055,26 +1045,8 @@ namespace BenMAP
 						{
 							try
 							{
-								int prevTop = 0;
-								if( !CommonClass.BatchMode )
-								{
-									prevTop = Console.CursorTop;
-								}
 
 								BenMAP benMAP = new BenMAP("");
-
-								// This code clears the command line of output text from appManager1.LoadExtensions();
-								// called during the initialization of BenMAP
-								if( !CommonClass.BatchMode )
-								{
-									int currTop = Console.CursorTop;
-									for (int i = currTop; i > prevTop - 1; i--)
-									{
-										Console.SetCursorPosition(0, i);
-										Console.Write(new String(' ', Console.BufferWidth));
-									}
-									Console.SetCursorPosition(0, prevTop);
-								}
 
 								Console.Write("Generating Report (APVR)...");
 								BatchReportAPVR batchReportAPVR = batchBase as BatchReportAPVR;

--- a/BenMAP/Configuration/ConfigurationCommonClass.cs
+++ b/BenMAP/Configuration/ConfigurationCommonClass.cs
@@ -374,7 +374,7 @@ namespace BenMAP.Configuration
 		{
 			bool isBatch = false;
 
-			if (CommonClass.InputParams != null && CommonClass.InputParams.Count() > 0 && CommonClass.InputParams[0].ToLower().Contains(".ctlx"))
+			if (CommonClass.BatchMode)
 			{
 				isBatch = true;
 			}

--- a/BenMAP/Configuration/HealthImpactFunctions.cs
+++ b/BenMAP/Configuration/HealthImpactFunctions.cs
@@ -1103,7 +1103,7 @@ namespace BenMAP
 				bool isBatch = false;
 				string tip = "Creating health impact function result. Please wait.";
 				string sProgressBar = "";
-				if (CommonClass.InputParams != null && CommonClass.InputParams.Count() > 0 && CommonClass.InputParams[0].ToLower().Contains(".ctlx"))
+				if (CommonClass.BatchMode)
 				{
 					isBatch = true;
 				}
@@ -1367,9 +1367,6 @@ namespace BenMAP
 				string populationStatus = "Loading Population Data...";
 				if (isBatch)
 				{
-					//Console.SetCursorPosition(0, Console.CursorTop);
-					//Console.Write(new String(' ', Console.BufferWidth));
-					//Console.SetCursorPosition(0, Console.CursorTop - 1);
 					Console.Write(populationStatus);
 				}
 				else
@@ -1445,9 +1442,6 @@ namespace BenMAP
 							else
 							{
 								populationStatus = "Loading Population Data (Cached)...";
-								//Console.SetCursorPosition(0, Console.CursorTop);
-								//Console.Write(new String(' ', Console.BufferWidth));
-								//Console.SetCursorPosition(0, Console.CursorTop - 1);
 								Console.Write(populationStatus);
 							}
 						}
@@ -1479,10 +1473,7 @@ namespace BenMAP
 
 					if (isBatch)
 					{
-						//Console.SetCursorPosition(populationStatus.Length, Console.CursorTop);
-						//Console.Write(new String(' ', Console.BufferWidth));
-						//Console.SetCursorPosition(populationStatus.Length, Console.CursorTop - 1);
-						Console.Write("Completed" + Environment.NewLine);
+						Console.WriteLine("Completed");
 					}
 				}
 				catch (Exception ex)
@@ -1867,10 +1858,6 @@ namespace BenMAP
 										Console.Write(".");
 										Thread.Sleep(1000);
 									}
-
-									Console.SetCursorPosition(progressString.Length, Console.CursorTop);
-									Console.Write(new String(' ', Console.BufferWidth));
-									Console.SetCursorPosition(progressString.Length, Console.CursorTop - 1);
 								}
 								else
 									break;
@@ -1889,10 +1876,6 @@ namespace BenMAP
 
 					if (finishHIF.Exception != null)        //Check on status of the tasks running HIF, clear the console and provide final update
 						throw finishHIF.Exception;
-
-					Console.SetCursorPosition(0, Console.CursorTop);
-					Console.Write(new String(' ', Console.BufferWidth));
-					Console.SetCursorPosition(0, Console.CursorTop);
 
 					if (finishHIF.Status == TaskStatus.RanToCompletion)
 						Console.WriteLine("Processing Health Impact Functions...Completed");
@@ -2012,10 +1995,7 @@ namespace BenMAP
 				else
 				{
 					Configuration.ConfigurationCommonClass.SaveCRFRFile(CommonClass.BaseControlCRSelectFunctionCalculateValue, _filePath);
-					//Console.SetCursorPosition(0, Console.CursorTop);
-					//Console.Write(new String(' ', Console.BufferWidth));
-					//Console.SetCursorPosition(0, Console.CursorTop - 1);
-					Console.WriteLine("Results Saved At:" + Environment.NewLine + _filePath);
+					Console.WriteLine("Results saved at:" + _filePath);
 				}
 			}
 			catch (Exception e)

--- a/BenMAP/DataSource/DataSourceCommonClass.cs
+++ b/BenMAP/DataSource/DataSourceCommonClass.cs
@@ -3265,7 +3265,7 @@ Math.Cos(Y0 / 180 * Math.PI) * Math.Cos(Y1 / 180 * Math.PI) * Math.Pow(Math.Sin(
 						}
 						i++;
 					}
-					if (!(CommonClass.InputParams != null && CommonClass.InputParams.Count() > 0 && CommonClass.InputParams[0].ToLower().Contains(".ctlx")))
+					if (!(CommonClass.BatchMode) )
 					{
 						string warningtip = "";
 						if (iMonitorName < 0) warningtip = "'Monitor Name', ";


### PR DESCRIPTION
Remove remaining code that uses explicit console cursor positioning
to clear the console screen at various points. Setting the cursor
position causes an exeception when running in batch mode with output
connected to a pipe rather than an actual console.